### PR TITLE
Configure env with db setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,4 @@ yarn-error.log
 package-lock.json
 .DS_Store
 
-config/dev.env
-config/prod.env
-.env
+dotenv/prod.env

--- a/config/config.js
+++ b/config/config.js
@@ -1,0 +1,43 @@
+const env = process.env.NODE_ENV;
+const dotenv = require('dotenv');
+
+const envPath = env === 'production'
+  ? `${__dirname}/../dotenv/prod.env`
+  : env === 'development'
+    ? `${__dirname}/../dotenv/dev.env`
+    : `${__dirname}/../dotenv/.env`;
+dotenv.config({ path: envPath });
+
+const similarOption = {
+  username: process.env.DB_USER,
+  password: process.env.DB_PASSWORD,
+  database: process.env.DB_DATABASE,
+  host: process.env.DB_HOST,
+  port: process.env.DB_PORT,
+  dialect: process.env.DB_TYPE,
+};
+
+module.exports = {
+  development: {
+    ...similarOption,
+    define: {
+      underscored: false,
+    },
+  },
+  test: {
+    ...similarOption,
+    define: {
+      underscored: false,
+    },
+  },
+  production: {
+    ...similarOption,
+    dialectOptions: {
+      ssl: {},
+    },
+    define: {
+      underscored: false,
+    },
+    pool: { 'max': 5, 'min': 0, 'idle': 10000 },
+  },
+};

--- a/dotenv/.env
+++ b/dotenv/.env
@@ -4,6 +4,6 @@ DB_USER=hyochan
 DB_PASSWORD=password
 DB_PORT=3306
 DB_DATABASE=test_db
-production=false
+DB_TYPE=mysql
 
 JWT_SECRET=dooboolab

--- a/dotenv/dev.env
+++ b/dotenv/dev.env
@@ -1,0 +1,9 @@
+DB_CONNECTOR=mysql
+DB_HOST=127.0.0.1
+DB_USER=hyochan
+DB_PASSWORD=password
+DB_PORT=3306
+DB_DATABASE=test_db
+DB_TYPE=mysql
+
+JWT_SECRET=dooboolab

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,5 +1,6 @@
 import { Sequelize, Options, Op } from 'sequelize';
-require('dotenv').config();
+const env = process.env.NODE_ENV || 'development';
+const config = require('../../config/config')[env];
 
 const operatorsAliases = {
   $eq: Op.eq,
@@ -38,21 +39,11 @@ const operatorsAliases = {
   $col: Op.col,
 };
 
-const options: Options = {
-  // dialect: process.env.DB_CONNECTOR ? process.env.DB_CONNECTOR : 'mysql',
-  host: process.env.DB_HOST ? process.env.DB_HOST : '127.0.0.1',
-  dialect: 'mysql',
-  define: {
-    underscored: false,
-  },
-  // operatorsAliases: false,
-};
-
 const sequelize = new Sequelize(
-  process.env.DB_DATABASE ? process.env.DB_DATABASE : 'test_db',
-  process.env.DB_USER ? process.env.DB_USER : 'hyochan',
-  process.env.DB_PASSWORD ? process.env.DB_PASSWORD : 'password',
-  options,
+  config.database,
+  config.username,
+  config.password,
+  config,
 );
 
 sequelize.sync();


### PR DESCRIPTION
* Manage dotenv based on the `NODE_ENV`
* Use that base `env` params and use it in `seqeulize` db params.