### PR TITLE
refactor duplicate interface define for MyContext

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ts-apollo-sequelize",
   "version": "0.0.1",
-  "description": "Graphql Yoga Typescript Example",
+  "description": "Graphql Apollo Sequelize Typescript Example",
   "main": "src/server.ts",
   "repository": "https://github.com/dooboolab/ts-graphql-yoga-example",
   "author": "dooboolab",

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,8 +1,9 @@
-import models, { ModelType } from './models';
+import models from './models';
 
 import { ApolloServer } from 'apollo-server-express';
 import { Http2Server } from 'http2';
 import { JwtUser } from './utils/auth';
+import { MyContext } from './context';
 import { PubSub } from 'graphql-subscriptions';
 import { User } from './models/User';
 import { allResolvers } from './resolvers';
@@ -34,12 +35,7 @@ const getToken = (req: Express.Request & any): string => {
 
 const createApolloServer = (): ApolloServer => new ApolloServer({
   typeDefs: importSchema('schemas/schema.graphql'),
-  context: ({ req }): {
-    getUser: () => Promise<User>;
-    models: ModelType;
-    pubsub: PubSub;
-    appSecret: string;
-  } => ({
+  context: ({ req }): MyContext => ({
     getUser: (): Promise<User> => {
       const { User: userModel } = models;
       const token = getToken(req);

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,3 @@
-import models from './models';
-
 import { ApolloServer } from 'apollo-server-express';
 import { Http2Server } from 'http2';
 import { JwtUser } from './utils/auth';
@@ -12,6 +10,7 @@ import { createServer as createHttpServer } from 'http';
 import express from 'express';
 import { importSchema } from 'graphql-import';
 import jwt from 'jsonwebtoken';
+import models from './models';
 
 require('dotenv').config();
 


### PR DESCRIPTION
`MyContext` is already defined and export as an interface, so just use it.